### PR TITLE
Add Docker Hub token verification and HITL refresh scripts

### DIFF
--- a/scripts/hitl-update-token.sh
+++ b/scripts/hitl-update-token.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Ensure shell tracing (xtrace) is disabled so credentials are never logged
+set +x 2>/dev/null || true
+set -euo pipefail
+
+# Human-In-The-Loop script to refresh Docker Hub token, verify authentication,
+# update GitHub repository secrets, and rerun the failed CI workflow.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+USERNAME="${DOCKERHUB_USERNAME:-jonbaldie}"
+
+# Scrub token from memory on exit, interrupt, or termination
+trap 'unset TOKEN DOCKERHUB_TOKEN 2>/dev/null || true' EXIT INT TERM
+
+echo "========================================================"
+echo " Docker Hub Token Refresh & CI Verification Loop (HITL)"
+echo "========================================================"
+echo "1. Go to: https://app.docker.com/settings/personal-access-tokens"
+echo "2. Generate a new Personal Access Token with Read & Write permissions."
+echo ""
+
+while true; do
+  if [ -z "${DOCKERHUB_TOKEN:-}" ]; then
+    # Read token silently so it is not visible on terminal or in history
+    read -rsp "Enter the new Docker Hub Personal Access Token: " TOKEN
+    echo ""
+  else
+    TOKEN="$DOCKERHUB_TOKEN"
+  fi
+
+  if [ -z "$TOKEN" ]; then
+    echo "Token cannot be empty. Try again."
+    unset DOCKERHUB_TOKEN || true
+    continue
+  fi
+
+  echo "Verifying token against Docker Hub registry..."
+  if DOCKERHUB_USERNAME="$USERNAME" DOCKERHUB_TOKEN="$TOKEN" "$SCRIPT_DIR/verify-docker-auth.sh"; then
+    echo "Authentication verified successfully!"
+    break
+  else
+    echo "Token verification failed. Please check the token and try again."
+    unset DOCKERHUB_TOKEN TOKEN || true
+  fi
+done
+
+echo ""
+echo "Updating GitHub repository secret DOCKERHUB_TOKEN..."
+# Pipe secret directly via stdin to prevent command-line exposure
+printf '%s' "$TOKEN" | gh secret set DOCKERHUB_TOKEN --repo "${GITHUB_REPOSITORY:-jonbaldie/varnish}"
+echo "GitHub secret updated successfully."
+
+# Wipe token from memory immediately after updating secret
+unset TOKEN DOCKERHUB_TOKEN || true
+
+echo ""
+echo "Triggering re-run of failed CI job (run 33871162122)..."
+gh run rerun 33871162122 --failed --repo "${GITHUB_REPOSITORY:-jonbaldie/varnish}"
+echo "CI rerun dispatched! Monitor progress with: gh run watch 33871162122"

--- a/scripts/verify-docker-auth.sh
+++ b/scripts/verify-docker-auth.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Ensure shell tracing (xtrace) is disabled so credentials are never printed
+set +x 2>/dev/null || true
+set -euo pipefail
+
+# Verifies Docker Hub authentication against registry token service
+USERNAME="${DOCKERHUB_USERNAME:-jonbaldie}"
+TOKEN="${DOCKERHUB_TOKEN:-}"
+
+# Ensure token is cleared from memory on exit
+trap 'unset TOKEN 2>/dev/null || true' EXIT
+
+if [ -z "$TOKEN" ]; then
+    echo "FAIL: DOCKERHUB_TOKEN is empty or not set" >&2
+    exit 1
+fi
+
+echo "Verifying Docker Hub credentials for user: $USERNAME"
+
+# Pass credentials securely via curl config stdin to prevent exposure in process table (ps aux)
+RESPONSE=$(printf 'user = "%s:%s"\n' "$USERNAME" "$TOKEN" | curl -s -i --config - "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${USERNAME}/varnish:pull,push")
+
+HTTP_STATUS=$(echo "$RESPONSE" | grep -E '^HTTP/' | tail -1 | awk '{print $2}')
+
+if [ "$HTTP_STATUS" = "200" ]; then
+    echo "OK: Docker Hub token is valid and authorized for ${USERNAME}/varnish"
+    exit 0
+else
+    echo "FAIL: Docker Hub authentication failed with HTTP ${HTTP_STATUS}"
+    # Only show safe error details, never full response
+    echo "$RESPONSE" | grep -E '("details"|"message"|unauthorized)' || echo "$RESPONSE" | grep -E '^HTTP/'
+    exit 1
+fi


### PR DESCRIPTION
### Summary

Fixes CI failure where Docker Hub Personal Access Token expired (Hypothesis 1: `DOCKERHUB_TOKEN` reached its 90-day expiry limit).

### Security Hardening Measures
- **No secrets in process table (`ps aux`)**: `scripts/verify-docker-auth.sh` pipes credentials into `curl --config -` via stdin rather than CLI flags.
- **Silent user input**: `scripts/hitl-update-token.sh` uses `read -rsp` so token text is never rendered to terminal screen or saved in shell history.
- **Immediate memory scrub**: `trap 'unset TOKEN DOCKERHUB_TOKEN' EXIT INT TERM` ensures secrets are scrubbed from shell memory immediately upon completion or interruption.
- **Disabled trace**: `set +x` prevents shell execution tracing from logging secret values.